### PR TITLE
support loader plugins that use locate & reload bug fix

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28,9 +28,11 @@ var getModuleRecord = function getModuleRecord(moduleName) {
                 }
                 var fullModulePath = location.origin + '/' + moduleName;
                 var loadsKey = Object.keys(System.loads).find(function (n) {
-                    return n.indexOf(fullModulePath) !== -1;
+                    return n.indexOf(fullModulePath) !== -1 || System.loads[n].address.indexOf(fullModulePath) !== -1;
                 });
                 // normalize does not yield a key which would match the key used in System.loads, so we have to improvise a bit
+                // also, the module name may not match the address for plugins making use of the SystemJS locate hook,
+                //   so check the address also
                 if (loadsKey) {
                     return {
                         v: System.loads[loadsKey]

--- a/dist/index.js
+++ b/dist/index.js
@@ -132,6 +132,10 @@ var deleteModule = function deleteModule(moduleToDelete, from) {
 var reload = function reload(moduleName) {
     var start = new Date().getTime();
 
+    //importers is currently unreliable, because it doesn't automatically catch modules that load after systemjs-hmr
+    //so we have to fix up the importers every time we need to use it
+    pushImporters(System.loads, true);
+
     modulesJustDeleted = {}; // TODO use weakmap
     return getModuleRecord(moduleName).then(function (module) {
         deleteModule(module, 'origin');

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,9 +21,11 @@ const getModuleRecord = (moduleName) => {
             }
             const fullModulePath = location.origin + '/' + moduleName
             const loadsKey = Object.keys(System.loads).find((n) => {
-                return n.indexOf(fullModulePath) !== -1
+                return (n.indexOf(fullModulePath) !== -1) || (System.loads[n].address.indexOf(fullModulePath) !== -1)
             })
             // normalize does not yield a key which would match the key used in System.loads, so we have to improvise a bit
+            // also, the module name may not match the address for plugins making use of the SystemJS locate hook,
+            //   so check the address also
             if (loadsKey) {
                 return System.loads[loadsKey]
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -121,6 +121,10 @@ const deleteModule = (moduleToDelete, from) => {
 
 const reload = (moduleName) => {
     const start = new Date().getTime()
+    
+    //importers is currently unreliable, because it doesn't automatically catch modules that load after systemjs-hmr
+    //so we have to fix up the importers every time we need to use it
+    pushImporters(System.loads,true); 
 
     modulesJustDeleted = {}  // TODO use weakmap
     return getModuleRecord(moduleName).then(module => {


### PR DESCRIPTION
support loader plugins that use locate
fixed unreliable reload for modules loaded after systemjs-hmr