### PR TITLE
fix(*): copy second level of the prototype chain

### DIFF
--- a/lib/next.js
+++ b/lib/next.js
@@ -22,6 +22,8 @@ const _System = {
     ...System
 }
 
+_System.__proto__.__proto__ = {...System.__proto__.__proto__};
+
 
 // Stores state systemjs-hmr needs access to
 const reloader = System.reloader = {
@@ -243,10 +245,9 @@ const reload = System.reload = (moduleName, meta = {}) => {
                     // If roots have been specified in meta, load those, otherwise load our best guess
                     (meta.roots ? meta.roots : roots)
                         .map(root => System.load(root)))
-                    .then(() => {
-                        reloader.loadCache.clear()
-                    })
+                    // .then(() => {
+                    //     reloader.loadCache.clear()
+                    // })
             })
     })
 }
-


### PR DESCRIPTION
This is needed because the prototype chain of `SystemJS` has a length of 2.