### PR TITLE
Fix issue #5

### DIFF
--- a/dist/next.js
+++ b/dist/next.js
@@ -124,14 +124,12 @@ System.set('@@hot', System.newModule({
  * @returns {Array}
  */
 var findDirectDependants = function findDirectDependants(moduleName) {
-    return Object.values(System.defined).filter(function (_ref2) {
-        var normalizedDeps = _ref2.normalizedDeps;
-        return normalizedDeps.find(function (name) {
+    return Object.keys(System.defined).filter(function (key) {
+        return (System.defined[key].normalizedDeps || []).find(function (name) {
             return name == moduleName;
         });
-    }).map(function (_ref3) {
-        var name = _ref3.name;
-        return name;
+    }).map(function (key) {
+        return System.defined[key].name;
     });
 };
 
@@ -201,9 +199,9 @@ var reload = System.reload = function (moduleName) {
     reloader.lock.then(function () {
         return reloader.lock = _System.normalize.apply(System, [moduleName]).then(function (name) {
             return findDependants(name);
-        }).then(function (_ref4) {
-            var dependants = _ref4.dependants,
-                roots = _ref4.roots;
+        }).then(function (_ref2) {
+            var dependants = _ref2.dependants,
+                roots = _ref2.roots;
 
             // Delete all dependent modules
 

--- a/dist/next.js
+++ b/dist/next.js
@@ -142,7 +142,9 @@ var findDirectDependants = function findDirectDependants(moduleName) {
 var findDependants = function findDependants(moduleName) {
 
     // A queue of modules to explore next, starting with moduleName
-    var next = [moduleName];
+    var next = [];
+
+    if (System.defined[moduleName]) next.push(moduleName);
 
     // A Set of all modules that depend on this one (includes moduleName)
     var dependents = new Set();

--- a/dist/next.js
+++ b/dist/next.js
@@ -128,8 +128,6 @@ var findDirectDependants = function findDirectDependants(moduleName) {
         return (System.defined[key].normalizedDeps || []).find(function (name) {
             return name == moduleName;
         });
-    }).map(function (key) {
-        return System.defined[key].name;
     });
 };
 

--- a/lib/next.js
+++ b/lib/next.js
@@ -141,7 +141,9 @@ const findDirectDependants = (moduleName) => {
 const findDependants = (moduleName) => {
 
     // A queue of modules to explore next, starting with moduleName
-    const next = [moduleName]
+    const next = []
+
+    if(System.defined[moduleName]) next.push(moduleName)
 
     // A Set of all modules that depend on this one (includes moduleName)
     const dependents = new Set()

--- a/lib/next.js
+++ b/lib/next.js
@@ -128,7 +128,6 @@ System.set('@@hot', System.newModule({
 const findDirectDependants = (moduleName) => {
     return Object.keys(System.defined)
         .filter((key) => (System.defined[key].normalizedDeps || []).find(name => name == moduleName))
-        .map((key) => System.defined[key].name)
 }
 
 

--- a/lib/next.js
+++ b/lib/next.js
@@ -126,9 +126,9 @@ System.set('@@hot', System.newModule({
  * @returns {Array}
  */
 const findDirectDependants = (moduleName) => {
-    return Object.values(System.defined)
-        .filter(({normalizedDeps}) => normalizedDeps.find(name => name == moduleName))
-        .map(({name}) => name)
+    return Object.keys(System.defined)
+        .filter((key) => (System.defined[key].normalizedDeps || []).find(name => name == moduleName))
+        .map((key) => System.defined[key].name)
 }
 
 


### PR DESCRIPTION
This fixes issue #5 in the new `next.js` version. Additionally, at least my Chrome 49.0 doesn't support `Object.values` so I replaced it with `Object.keys`. Overall its browser support [doesn't look too good yet](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values#Browser_compatibility).