### PR TITLE
prevent bad module load attempt from getting locked in fail state

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -237,6 +237,8 @@ System.reload = function (moduleName) {
         // chain promises TODO we can solve this better- this often leads to the same module being reloaded mutliple times
         currentHotReload = currentHotReload.then(function () {
             return reload(moduleName);
+        }).catch(function (err) {
+            return console.log(err);
         });
     }
 

--- a/dist/next.js
+++ b/dist/next.js
@@ -225,5 +225,7 @@ var reload = System.reload = function (moduleName) {
             //     reloader.loadCache.clear()
             // })
         });
+    }).catch(function (err) {
+        return console.log(err);
     });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -242,7 +242,7 @@ System.reload = (moduleName) => {
 
     } else {
         // chain promises TODO we can solve this better- this often leads to the same module being reloaded mutliple times
-        currentHotReload = currentHotReload.then(() => reload(moduleName))
+        currentHotReload = currentHotReload.then(() => reload(moduleName)).catch((err) => console.log(err))
     }
 
     return Promise.resolve(true)

--- a/lib/next.js
+++ b/lib/next.js
@@ -233,5 +233,5 @@ const reload = System.reload = (moduleName, meta = {}) => {
                 //     reloader.loadCache.clear()
                 // })
             })
-    })
+    }).catch((err) => console.log(err))
 }


### PR DESCRIPTION
When a reload would fail, the promise queue which prevents simultaneous reloads would enter a fail state preventing all future reloads from succeeding.  By adding a catch, it resets that fail state.  This helps if you are doing something like:

1. reload goodfile1.js
2. reload goodfile2.js
3. reload file-that-is-not-a-module.any
4. reload goodfile1.js
5. reload goodfile2.js

Without this change, the reload function breaks permanently on step 3.  With the change, it should fail step 3 and resume working again at step 4.