### PR TITLE
Adding option to turn off console logging

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,17 +1,23 @@
 'use strict';
 
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.setDebugLogging = setDebugLogging;
 var originalSystemImport = System.import;
 var lastFailedSystemImport = null;
 var failedReimport = null;
 var currentHotReload = Promise.resolve();
 var modulesJustDeleted = null;
 var clientImportedModules = [];
+var debugLogging = true;
 
 var d = function d() {
     for (var _len = arguments.length, segments = Array(_len), _key = 0; _key < _len; _key++) {
         segments[_key] = arguments[_key];
     }
 
+    if (!debugLogging) return;
     console.log(segments.reduce(function (message, segment) {
         return message + " " + segment;
     }));
@@ -244,3 +250,7 @@ System.reload = function (moduleName) {
 
     return Promise.resolve(true);
 };
+
+function setDebugLogging(value) {
+    debugLogging = value;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,11 @@ let failedReimport = null
 let currentHotReload = Promise.resolve()
 let modulesJustDeleted = null
 let clientImportedModules = []
+let debugLogging = true
 
 let d = (...segments) => {
+    if (!debugLogging)
+        return
     console.log(
         segments.reduce(
             (message, segment) => message + " " + segment))
@@ -248,4 +251,6 @@ System.reload = (moduleName) => {
     return Promise.resolve(true)
 }
 
-
+export function setDebugLogging(value) {
+    debugLogging = value;
+}


### PR DESCRIPTION
First off, thanks for your work on this!

The console logging is very helpful sometimes, but when I already have everything set up for hot reloading it ends up cluttering my console every time I hot reload. I noticed that in next.js there is no logging, but that version does not work for me right now. So this pull request just adds a way to turn off debug logging if you don't want it. Sample usage:

```js
import {setDebugLogging} from 'systemjs-hmr';

setDebugLogging(false);
```

Note that anybody who uses this will have to remove their `setDebugLogging` call when they upgrade to next.js.