### PR TITLE
Fix issue with unload and systemjs >= 0.20.x

### DIFF
--- a/dist/util.js
+++ b/dist/util.js
@@ -175,8 +175,9 @@ export var unload = curryN(1, function (context, moduleName) {
     logger("unloading " + moduleName);
     if (System.has(moduleName)) {
         var module_1 = System.get(moduleName);
-        if (typeof module_1.__unload == 'function')
-            module_1.__unload();
+        var unloadFunc = module_1.__unload || (module_1.default ? module_1.default.__unload : undefined);
+        if (typeof unloadFunc == 'function')
+            unloadFunc();
     }
     System.delete(moduleName);
 });

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -248,8 +248,9 @@ export const unload = curryN(1, (context: Context, moduleName: string) => {
     if (System.has(moduleName)) {
         const module = System.get(moduleName)
 
-        if (typeof module.__unload == 'function')
-            module.__unload()
+        var unloadFunc = module.__unload || (module.default ? module.default.__unload : undefined);
+        if (typeof unloadFunc == 'function')
+        unloadFunc();
     }
 
     System.delete(moduleName)


### PR DESCRIPTION
fixes #32 

This allows `unload` mechanism to work if using systemjs 0.20.0 or greater (upto 0.21.5).

As of systemjs 0.20.X, getting a module from the registry returns a module, and on that is a `default` property, and on that is the `unload` function, rather than directly on the module object. The changes made here, fallback to finding the unload function in it's new location if it isn't present on the first location. 
Tested with 0.19.47 up to 0.21.5.